### PR TITLE
Feat/image absolute urls

### DIFF
--- a/apps/taste_test/services.py
+++ b/apps/taste_test/services.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Dict, List, Optional
 
 from django.contrib.auth import get_user_model
+from django.conf import settings
 
 from .models import PreferenceTestResult
 
@@ -67,65 +68,56 @@ class TasteTestData:
         "달콤과일파": {
             "name": "달콤과일파",
             "enum": "SWEET_FRUIT",
-            "description": "당신은 부드럽고 달콤한 맛에서 행복을 느끼는군요! 쓴맛이나 강한 신맛보다는, 입안 가득 퍼지는 과일의 향기와 기분 좋은 달콤함을 즐기는 타입입니다.",
+            "description": "당신은 부드럽고 달콤한 맛에서 행복을 느끼는군요!\n쓴맛이나 강한 신맛보다는, 입안 가득 퍼지는 과일의 향기와\n기분 좋은 달콤함을 즐기는 타입입니다.",
             "characteristics": ["달콤함", "과일향", "로맨틱", "부드러움"],
-            "image_url": "images/types/sweet_fruit.png",
         },
         "상큼톡톡파": {
             "name": "상큼톡톡파",
             "enum": "FRESH_FIZZY",
-            "description": "당신은 평범한 걸 거부한다! 입맛을 깨우는 새콤함과 톡 쏘는 청량감에서 즐거움을 느끼는, 활기 넘치는 타입입니다. 세련된 취향을 가졌네요.",
+            "description": "당신은 평범한 걸 거부한다!\n입맛을 깨우는 새콤함과 톡 쏘는 청량감에서 즐거움을 느끼는,\n활기 넘치는 타입입니다. 세련된 취향을 가졌네요.",
             "characteristics": ["상큼함", "톡톡함", "경쾌함", "청량감"],
-            "image_url": "images/types/fresh_fizzy.png",
         },
         "묵직여운파": {
             "name": "묵직여운파",
             "enum": "HEAVY_LINGERING",
-            "description": "당신은 '술은 술다워야지' 라고 생각하는군요. 알코올의 존재감이 느껴지는, 진하고 깊은 풍미와 묵직한 여운을 즐기는 타입입니다.",
+            "description": "당신은 '술은 술다워야지' 라고 생각하는군요.\n알코올의 존재감이 느껴지는, 진하고 깊은 풍미와\n묵직한 여운을 즐기는 타입입니다.",
             "characteristics": ["묵직함", "진한맛", "여운", "존재감"],
-            "image_url": "images/types/heavy_lingering.png",
         },
         "깔끔고소파": {
             "name": "깔끔고소파",
             "enum": "CLEAN_SAVORY",
-            "description": "당신은 인위적인 맛보다는, 재료 본연의 깔끔하고 담백한 맛을 즐길 줄 아는 미식가시네요! 쌀이나 곡물이 주는 은은한 고소함과 군더더기 없는 마무리를 좋아합니다.",
+            "description": "당신은 인위적인 맛보다는, 재료 본연의 깔끔하고 담백한 맛을 즐길 줄 아는 미식가시네요!\n쌀이나 곡물이 주는 은은한 고소함과\n군더더기 없는 마무리를 좋아합니다.",
             "characteristics": ["깔끔함", "고소함", "담백함", "자연스러움"],
-            "image_url": "images/types/clean_savory.png",
         },
         "향긋단정파": {
             "name": "향긋단정파",
             "enum": "FRAGRANT_NEAT",
-            "description": "강렬한 맛보다는 은은하게 피어오르는 꽃이나 과일 향기, 그리고 부드러운 목넘김을 즐기는 섬세한 타입입니다.",
+            "description": "강렬한 맛보다는 은은하게 피어오르는 꽃이나 과일 향기,\n그리고 부드러운 목넘김을 즐기는\n섬세한 타입입니다.",
             "characteristics": ["향긋함", "단정함", "섬세함", "우아함"],
-            "image_url": "images/types/fragrant_neat.png",
         },
         "상큼깔끔파": {
             "name": "상큼깔끔파",
             "enum": "FRESH_CLEAN",
-            "description": "상큼한 첫맛으로 입맛을 돋우되, 끝맛은 군더더기 없이 깔끔하게 떨어지는 맛을 즐기는 당신! 세련된 취향을 가졌네요.",
+            "description": "상큼한 첫맛으로 입맛을 돋우되,\n끝맛은 군더더기 없이 깔끔하게 떨어지는 맛을 즐기는 당신!\n세련된 취향을 가졌네요.",
             "characteristics": ["상큼함", "깔끔함", "세련됨", "균형감"],
-            "image_url": "images/types/fresh_clean.png",
         },
         "묵직달콤파": {
             "name": "묵직달콤파",
             "enum": "HEAVY_SWEET",
-            "description": "입안을 꽉 채우는 진한 질감과 함께 오는 기분 좋은 달콤함을 선호하는 당신! 디저트 와인처럼 풍성한 맛을 즐기는군요.",
+            "description": "입안을 꽉 채우는 진한 질감과 함께 오는\n기분 좋은 달콤함을 선호하는 당신!\n디저트 와인처럼 풍성한 맛을 즐기는군요.",
             "characteristics": ["묵직함", "달콤함", "풍성함", "진한맛"],
-            "image_url": "images/types/heavy_sweet.png",
         },
         "달콤고소파": {
             "name": "달콤고소파",
             "enum": "SWEET_SAVORY",
-            "description": "달콤하지만 끝은 구수한, 밸런스 좋은 맛을 선호하는 당신! 부드러운 첫인상과 담백한 마무리를 모두 중요하게 생각하는군요.",
+            "description": "달콤하지만 끝은 구수한, 밸런스 좋은 맛을 선호하는 당신!\n부드러운 첫인상과 담백한 마무리를\n모두 중요하게 생각하는군요.",
             "characteristics": ["달콤함", "고소함", "균형", "조화"],
-            "image_url": "images/types/sweet_savory.png",
         },
         "미식가유형": {
             "name": "미식가유형",
             "enum": "GOURMET",
-            "description": "상황에 따라 다양한 술의 매력을 즐길 줄 아는 술 애호가입니다. 새로운 술을 시도하는 데도 주저하지 않으며, 어떤 술이든 그 자체의 맛을 음미할 줄 아는 폭넓은 스펙트럼의 균형 잡힌 미식가입니다.",
+            "description": "상황에 따라 다양한 술의 매력을 즐길 줄 아는 술 애호가입니다.\n새로운 술을 시도하는 데도 주저하지 않으며,\n어떤 술이든 그 자체의 맛을 음미할 줄 아는 폭넓은 스펙트럼의 균형 잡힌 미식가입니다.",
             "characteristics": ["다양성", "개방성", "균형감", "미식가적"],
-            "image_url": "images/types/gourmet.png",
         },
     }
 
@@ -223,11 +215,10 @@ class TasteTestData:
 
     @classmethod
     def get_image_url_by_enum(cls, enum_value: str) -> str:
-        """enum 값으로 이미지 URL 조회"""
-        for type_info in cls.TYPE_INFO.values():
-            if type_info["enum"] == enum_value:
-                return str(type_info["image_url"])
-        return str(cls.TYPE_INFO["미식가유형"]["image_url"])
+        """enum 값으로 이미지 URL 조회 (절대 URL 반환)"""
+        base_url = getattr(settings, 'BASE_URL', 'http://localhost:8000')
+        filename = f"{enum_value.lower()}.png"
+        return f"{base_url}/api/v1/taste-test/images/types/{filename}"
 
 
 class TasteTestService:
@@ -271,20 +262,27 @@ class TasteTestService:
 
     @staticmethod
     def get_type_info(korean_name: str) -> Dict:
-        """한국어 유형명으로 유형 정보 반환"""
-        return TasteTestData.TYPE_INFO.get(korean_name, TasteTestData.TYPE_INFO["미식가유형"])
+        """한국어 유형명으로 유형 정보 반환 (절대 URL로 변환)"""
+        type_info = TasteTestData.TYPE_INFO.get(korean_name, TasteTestData.TYPE_INFO["미식가유형"]).copy()
+        # 절대 URL로 변환
+        type_info['image_url'] = TasteTestData.get_image_url_by_enum(type_info['enum'])
+        return type_info
 
     @staticmethod
     def get_type_info_by_enum(enum_value: str) -> Dict:
-        """enum 값으로 유형 정보 반환"""
+        """enum 값으로 유형 정보 반환 (절대 URL로 변환)"""
         for type_info in TasteTestData.TYPE_INFO.values():
             if type_info["enum"] == enum_value:
-                return type_info
-        return TasteTestData.TYPE_INFO["미식가유형"]
+                result = type_info.copy()
+                result['image_url'] = TasteTestData.get_image_url_by_enum(enum_value)
+                return result
+        result = TasteTestData.TYPE_INFO["미식가유형"].copy()
+        result['image_url'] = TasteTestData.get_image_url_by_enum("GOURMET")
+        return result
 
     @staticmethod
     def get_image_url_by_enum(enum_value: str) -> str:
-        """enum 값으로 이미지 URL 반환"""
+        """enum 값으로 이미지 URL 반환 (절대 URL)"""
         return TasteTestData.get_image_url_by_enum(enum_value)
 
     @staticmethod
@@ -511,4 +509,4 @@ def process_taste_test(answers: Dict[str, str]) -> Dict:
 TASTE_QUESTIONS = TasteTestData.QUESTIONS
 ANSWER_SCORE_MAPPING = TasteTestData.ANSWER_MAPPING
 TASTE_TYPES = TasteTestData.TYPE_INFO
-TASTE_TYPE_IMAGES = {type_info["enum"]: type_info["image_url"] for type_info in TasteTestData.TYPE_INFO.values()}
+TASTE_TYPE_IMAGES = {type_info["enum"]: TasteTestData.get_image_url_by_enum(type_info["enum"]) for type_info in TasteTestData.TYPE_INFO.values()}

--- a/apps/taste_test/services.py
+++ b/apps/taste_test/services.py
@@ -5,8 +5,8 @@
 from decimal import Decimal
 from typing import Dict, List, Optional
 
-from django.contrib.auth import get_user_model
 from django.conf import settings
+from django.contrib.auth import get_user_model
 
 from .models import PreferenceTestResult
 
@@ -219,12 +219,12 @@ class TasteTestData:
         # 유효한 enum인지 확인
         for type_info in cls.TYPE_INFO.values():
             if type_info["enum"] == enum_value:
-                base_url = getattr(settings, 'BASE_URL', 'http://localhost:8000')
+                base_url = getattr(settings, "BASE_URL", "http://localhost:8000")
                 filename = f"{enum_value.lower()}.png"
                 return f"{base_url}/api/v1/taste-test/images/types/{filename}"
 
         # 존재하지 않는 enum의 경우 GOURMET 기본값 반환
-        base_url = getattr(settings, 'BASE_URL', 'http://localhost:8000')
+        base_url = getattr(settings, "BASE_URL", "http://localhost:8000")
         return f"{base_url}/api/v1/taste-test/images/types/gourmet.png"
 
 
@@ -272,7 +272,7 @@ class TasteTestService:
         """한국어 유형명으로 유형 정보 반환 (절대 URL로 변환)"""
         type_info = TasteTestData.TYPE_INFO.get(korean_name, TasteTestData.TYPE_INFO["미식가유형"]).copy()
         # 절대 URL로 변환
-        type_info['image_url'] = TasteTestData.get_image_url_by_enum(str(type_info['enum']))
+        type_info["image_url"] = TasteTestData.get_image_url_by_enum(str(type_info["enum"]))
         return type_info
 
     @staticmethod
@@ -281,10 +281,10 @@ class TasteTestService:
         for type_info in TasteTestData.TYPE_INFO.values():
             if type_info["enum"] == enum_value:
                 result = type_info.copy()
-                result['image_url'] = TasteTestData.get_image_url_by_enum(enum_value)
+                result["image_url"] = TasteTestData.get_image_url_by_enum(enum_value)
                 return result
         result = TasteTestData.TYPE_INFO["미식가유형"].copy()
-        result['image_url'] = TasteTestData.get_image_url_by_enum("GOURMET")
+        result["image_url"] = TasteTestData.get_image_url_by_enum("GOURMET")
         return result
 
     @staticmethod
@@ -516,4 +516,7 @@ def process_taste_test(answers: Dict[str, str]) -> Dict:
 TASTE_QUESTIONS = TasteTestData.QUESTIONS
 ANSWER_SCORE_MAPPING = TasteTestData.ANSWER_MAPPING
 TASTE_TYPES = TasteTestData.TYPE_INFO
-TASTE_TYPE_IMAGES = {str(type_info["enum"]): TasteTestData.get_image_url_by_enum(str(type_info["enum"])) for type_info in TasteTestData.TYPE_INFO.values()}
+TASTE_TYPE_IMAGES = {
+    str(type_info["enum"]): TasteTestData.get_image_url_by_enum(str(type_info["enum"]))
+    for type_info in TasteTestData.TYPE_INFO.values()
+}

--- a/apps/taste_test/services.py
+++ b/apps/taste_test/services.py
@@ -216,9 +216,16 @@ class TasteTestData:
     @classmethod
     def get_image_url_by_enum(cls, enum_value: str) -> str:
         """enum 값으로 이미지 URL 조회 (절대 URL 반환)"""
+        # 유효한 enum인지 확인
+        for type_info in cls.TYPE_INFO.values():
+            if type_info["enum"] == enum_value:
+                base_url = getattr(settings, 'BASE_URL', 'http://localhost:8000')
+                filename = f"{enum_value.lower()}.png"
+                return f"{base_url}/api/v1/taste-test/images/types/{filename}"
+
+        # 존재하지 않는 enum의 경우 GOURMET 기본값 반환
         base_url = getattr(settings, 'BASE_URL', 'http://localhost:8000')
-        filename = f"{enum_value.lower()}.png"
-        return f"{base_url}/api/v1/taste-test/images/types/{filename}"
+        return f"{base_url}/api/v1/taste-test/images/types/gourmet.png"
 
 
 class TasteTestService:
@@ -265,7 +272,7 @@ class TasteTestService:
         """한국어 유형명으로 유형 정보 반환 (절대 URL로 변환)"""
         type_info = TasteTestData.TYPE_INFO.get(korean_name, TasteTestData.TYPE_INFO["미식가유형"]).copy()
         # 절대 URL로 변환
-        type_info['image_url'] = TasteTestData.get_image_url_by_enum(type_info['enum'])
+        type_info['image_url'] = TasteTestData.get_image_url_by_enum(str(type_info['enum']))
         return type_info
 
     @staticmethod
@@ -509,4 +516,4 @@ def process_taste_test(answers: Dict[str, str]) -> Dict:
 TASTE_QUESTIONS = TasteTestData.QUESTIONS
 ANSWER_SCORE_MAPPING = TasteTestData.ANSWER_MAPPING
 TASTE_TYPES = TasteTestData.TYPE_INFO
-TASTE_TYPE_IMAGES = {type_info["enum"]: TasteTestData.get_image_url_by_enum(type_info["enum"]) for type_info in TasteTestData.TYPE_INFO.values()}
+TASTE_TYPE_IMAGES = {str(type_info["enum"]): TasteTestData.get_image_url_by_enum(str(type_info["enum"])) for type_info in TasteTestData.TYPE_INFO.values()}

--- a/apps/taste_test/tests/test_services.py
+++ b/apps/taste_test/tests/test_services.py
@@ -135,7 +135,7 @@ class TasteTestServiceTest(TestCase):
                 image_url = TasteTestService.get_image_url_by_enum(enum_type)
 
                 # 절대 URL 형식인지 확인
-                self.assertTrue(image_url.startswith(('http://', 'https://')))
+                self.assertTrue(image_url.startswith(("http://", "https://")))
                 # 올바른 경로와 파일명 확인
                 expected_path = f"/api/v1/taste-test/images/types/{enum_type.lower()}.png"
                 self.assertTrue(image_url.endswith(expected_path))
@@ -161,8 +161,8 @@ class TasteTestServiceTest(TestCase):
 
                 # 절대 URL 형식인지 확인
                 image_url = actual_type_info["image_url"]
-                self.assertTrue(image_url.startswith(('http://', 'https://')))
-                self.assertTrue(image_url.endswith('.png'))
+                self.assertTrue(image_url.startswith(("http://", "https://")))
+                self.assertTrue(image_url.endswith(".png"))
 
     def test_enum_image_mapping_consistency(self):
         """enum과 이미지 매핑 일관성 테스트"""
@@ -339,7 +339,7 @@ class TasteTestServiceImageTest(TestCase):
                 image_url = TasteTestService.get_image_url_by_enum(enum_type)
 
                 # 절대 URL 형식 확인
-                self.assertTrue(image_url.startswith(('http://', 'https://')))
+                self.assertTrue(image_url.startswith(("http://", "https://")))
                 # 파일명 확인
                 expected_filename = f"{enum_type.lower()}.png"
                 self.assertTrue(image_url.endswith(expected_filename))
@@ -363,7 +363,7 @@ class TasteTestServiceImageTest(TestCase):
                 self.assertIn("image_url", type_info)
 
                 image_url = type_info["image_url"]
-                self.assertTrue(image_url.startswith(('http://', 'https://')))
+                self.assertTrue(image_url.startswith(("http://", "https://")))
                 self.assertTrue(image_url.endswith(".png"))
 
     def test_enum_image_mapping_consistency(self):
@@ -708,7 +708,7 @@ class TasteTestServiceIntegrationWithImageTest(TestCase):
                 image_url = actual_type_info["image_url"]
 
                 # 절대 URL 형식 확인
-                self.assertTrue(image_url.startswith(('http://', 'https://')))
+                self.assertTrue(image_url.startswith(("http://", "https://")))
                 self.assertTrue(image_url.endswith(".png"))
 
                 # 파일명 형식 확인 (enum을 소문자로 변환한 형태)

--- a/apps/taste_test/tests/test_services.py
+++ b/apps/taste_test/tests/test_services.py
@@ -112,28 +112,33 @@ class TasteTestServiceTest(TestCase):
         self.assertEqual(result["scores"]["달콤과일파"], 3)
         self.assertEqual(result["info"]["name"], "달콤과일파")
 
-        # 이미지 URL 포함 확인
-        self.assertIn("image_url", result["info"])
-        self.assertEqual(result["info"]["image_url"], "images/types/sweet_fruit.png")
+        # 이미지 URL이 서비스 메서드와 일치하는지 확인
+        expected_url = TasteTestService.get_image_url_by_enum("SWEET_FRUIT")
+        self.assertEqual(result["info"]["image_url"], expected_url)
 
     def test_get_image_url_by_enum(self):
         """enum으로 이미지 URL 가져오기 테스트"""
         test_cases = [
-            ("SWEET_FRUIT", "images/types/sweet_fruit.png"),
-            ("FRESH_FIZZY", "images/types/fresh_fizzy.png"),
-            ("HEAVY_LINGERING", "images/types/heavy_lingering.png"),
-            ("CLEAN_SAVORY", "images/types/clean_savory.png"),
-            ("FRAGRANT_NEAT", "images/types/fragrant_neat.png"),
-            ("FRESH_CLEAN", "images/types/fresh_clean.png"),
-            ("HEAVY_SWEET", "images/types/heavy_sweet.png"),
-            ("SWEET_SAVORY", "images/types/sweet_savory.png"),
-            ("GOURMET", "images/types/gourmet.png"),
+            "SWEET_FRUIT",
+            "FRESH_FIZZY",
+            "HEAVY_LINGERING",
+            "CLEAN_SAVORY",
+            "FRAGRANT_NEAT",
+            "FRESH_CLEAN",
+            "HEAVY_SWEET",
+            "SWEET_SAVORY",
+            "GOURMET",
         ]
 
-        for enum_type, expected_url in test_cases:
+        for enum_type in test_cases:
             with self.subTest(enum_type=enum_type):
                 image_url = TasteTestService.get_image_url_by_enum(enum_type)
-                self.assertEqual(image_url, expected_url)
+
+                # 절대 URL 형식인지 확인
+                self.assertTrue(image_url.startswith(('http://', 'https://')))
+                # 올바른 경로와 파일명 확인
+                expected_path = f"/api/v1/taste-test/images/types/{enum_type.lower()}.png"
+                self.assertTrue(image_url.endswith(expected_path))
 
     def test_get_image_url_by_enum_invalid(self):
         """존재하지 않는 enum으로 이미지 URL 가져오기"""
@@ -141,7 +146,7 @@ class TasteTestServiceTest(TestCase):
         image_url = TasteTestService.get_image_url_by_enum(invalid_enum)
 
         # GOURMET 기본값이 반환되어야 함
-        expected_default = TASTE_TYPE_IMAGES["GOURMET"]
+        expected_default = TasteTestService.get_image_url_by_enum("GOURMET")
         self.assertEqual(image_url, expected_default)
 
     def test_taste_types_have_image_urls(self):
@@ -150,9 +155,14 @@ class TasteTestServiceTest(TestCase):
 
         for type_name, type_info in TASTE_TYPES.items():
             with self.subTest(type_name=type_name):
-                self.assertIn("image_url", type_info)
-                self.assertTrue(type_info["image_url"].startswith("images/types/"))
-                self.assertTrue(type_info["image_url"].endswith(".png"))
+                # get_type_info 메서드를 통해 실제 URL 확인
+                actual_type_info = TasteTestService.get_type_info(type_name)
+                self.assertIn("image_url", actual_type_info)
+
+                # 절대 URL 형식인지 확인
+                image_url = actual_type_info["image_url"]
+                self.assertTrue(image_url.startswith(('http://', 'https://')))
+                self.assertTrue(image_url.endswith('.png'))
 
     def test_enum_image_mapping_consistency(self):
         """enum과 이미지 매핑 일관성 테스트"""
@@ -162,12 +172,9 @@ class TasteTestServiceTest(TestCase):
             with self.subTest(type_name=type_name):
                 enum_value = type_info["enum"]
 
-                # TASTE_TYPE_IMAGES에 해당 enum이 있는지 확인
-                self.assertIn(enum_value, TASTE_TYPE_IMAGES)
-
-                # 두 매핑이 일치하는지 확인
-                direct_image_url = TASTE_TYPE_IMAGES[enum_value]
-                type_info_image_url = type_info["image_url"]
+                # 서비스 메서드로 얻은 URL들이 일치하는지 확인
+                direct_image_url = TasteTestService.get_image_url_by_enum(enum_value)
+                type_info_image_url = TasteTestService.get_type_info(type_name)["image_url"]
                 self.assertEqual(direct_image_url, type_info_image_url)
 
     def test_save_test_result_sweet_fruit_type(self):
@@ -316,21 +323,26 @@ class TasteTestServiceImageTest(TestCase):
     def test_get_image_url_by_enum_all_types(self):
         """모든 enum 타입별 이미지 URL 테스트"""
         test_cases = [
-            ("SWEET_FRUIT", "images/types/sweet_fruit.png"),
-            ("FRESH_FIZZY", "images/types/fresh_fizzy.png"),
-            ("HEAVY_LINGERING", "images/types/heavy_lingering.png"),
-            ("CLEAN_SAVORY", "images/types/clean_savory.png"),
-            ("FRAGRANT_NEAT", "images/types/fragrant_neat.png"),
-            ("FRESH_CLEAN", "images/types/fresh_clean.png"),
-            ("HEAVY_SWEET", "images/types/heavy_sweet.png"),
-            ("SWEET_SAVORY", "images/types/sweet_savory.png"),
-            ("GOURMET", "images/types/gourmet.png"),
+            "SWEET_FRUIT",
+            "FRESH_FIZZY",
+            "HEAVY_LINGERING",
+            "CLEAN_SAVORY",
+            "FRAGRANT_NEAT",
+            "FRESH_CLEAN",
+            "HEAVY_SWEET",
+            "SWEET_SAVORY",
+            "GOURMET",
         ]
 
-        for enum_type, expected_url in test_cases:
+        for enum_type in test_cases:
             with self.subTest(enum_type=enum_type):
                 image_url = TasteTestService.get_image_url_by_enum(enum_type)
-                self.assertEqual(image_url, expected_url)
+
+                # 절대 URL 형식 확인
+                self.assertTrue(image_url.startswith(('http://', 'https://')))
+                # 파일명 확인
+                expected_filename = f"{enum_type.lower()}.png"
+                self.assertTrue(image_url.endswith(expected_filename))
 
     def test_get_image_url_by_enum_invalid(self):
         """존재하지 않는 enum으로 이미지 URL 가져오기"""
@@ -338,18 +350,21 @@ class TasteTestServiceImageTest(TestCase):
         image_url = TasteTestService.get_image_url_by_enum(invalid_enum)
 
         # GOURMET 기본값이 반환되어야 함
-        expected_default = TASTE_TYPE_IMAGES["GOURMET"]
+        expected_default = TasteTestService.get_image_url_by_enum("GOURMET")
         self.assertEqual(image_url, expected_default)
 
     def test_taste_types_have_image_urls(self):
         """모든 TASTE_TYPES에 image_url이 포함되어 있는지 테스트"""
         from ..services import TASTE_TYPES
 
-        for type_name, type_info in TASTE_TYPES.items():
+        for type_name in TASTE_TYPES.keys():
             with self.subTest(type_name=type_name):
+                type_info = TasteTestService.get_type_info(type_name)
                 self.assertIn("image_url", type_info)
-                self.assertTrue(type_info["image_url"].startswith("images/types/"))
-                self.assertTrue(type_info["image_url"].endswith(".png"))
+
+                image_url = type_info["image_url"]
+                self.assertTrue(image_url.startswith(('http://', 'https://')))
+                self.assertTrue(image_url.endswith(".png"))
 
     def test_enum_image_mapping_consistency(self):
         """enum과 이미지 매핑 일관성 테스트"""
@@ -359,12 +374,9 @@ class TasteTestServiceImageTest(TestCase):
             with self.subTest(type_name=type_name):
                 enum_value = type_info["enum"]
 
-                # TASTE_TYPE_IMAGES에 해당 enum이 있는지 확인
-                self.assertIn(enum_value, TASTE_TYPE_IMAGES)
-
-                # 두 매핑이 일치하는지 확인
-                direct_image_url = TASTE_TYPE_IMAGES[enum_value]
-                type_info_image_url = type_info["image_url"]
+                # 두 메서드가 동일한 URL을 반환하는지 확인
+                direct_image_url = TasteTestService.get_image_url_by_enum(enum_value)
+                type_info_image_url = TasteTestService.get_type_info(type_name)["image_url"]
                 self.assertEqual(direct_image_url, type_info_image_url)
 
     def test_get_type_info_includes_image(self):
@@ -372,7 +384,10 @@ class TasteTestServiceImageTest(TestCase):
         type_info = TasteTestService.get_type_info("달콤과일파")
 
         self.assertIn("image_url", type_info)
-        self.assertEqual(type_info["image_url"], "images/types/sweet_fruit.png")
+        # 서비스 메서드와 일치하는지 확인
+        expected_url = TasteTestService.get_image_url_by_enum("SWEET_FRUIT")
+        self.assertEqual(type_info["image_url"], expected_url)
+
         self.assertEqual(type_info["name"], "달콤과일파")
         self.assertEqual(type_info["enum"], "SWEET_FRUIT")
 
@@ -510,8 +525,9 @@ class TasteTestServiceEdgeCaseTest(TestCase):
         # A 선택 시: 달콤과일파 2점, 상큼톡톡파 3점, 깔끔고소파 1점 → 상큼톡톡파 (단일)
         self.assertEqual(result["type"], "상큼톡톡파")
         self.assertEqual(result["scores"]["상큼톡톡파"], 3)
-        # 이미지 정보 확인
-        self.assertEqual(result["info"]["image_url"], "images/types/fresh_fizzy.png")
+        # 이미지 정보 확인 - 서비스 메서드와 일치
+        expected_url = TasteTestService.get_image_url_by_enum("FRESH_FIZZY")
+        self.assertEqual(result["info"]["image_url"], expected_url)
 
     def test_all_same_answer_b(self):
         """모든 답변이 B인 경우 (새로운 매핑)"""
@@ -522,8 +538,9 @@ class TasteTestServiceEdgeCaseTest(TestCase):
         # B 선택 시: 깔끔고소파 2점, 묵직여운파 3점, 달콤과일파 1점 → 묵직여운파 (단일)
         self.assertEqual(result["type"], "묵직여운파")
         self.assertEqual(result["scores"]["묵직여운파"], 3)
-        # 이미지 정보 확인
-        self.assertEqual(result["info"]["image_url"], "images/types/heavy_lingering.png")
+        # 이미지 정보 확인 - 서비스 메서드와 일치
+        expected_url = TasteTestService.get_image_url_by_enum("HEAVY_LINGERING")
+        self.assertEqual(result["info"]["image_url"], expected_url)
 
     def test_partial_answers(self):
         """일부 답변만 있는 경우"""
@@ -546,7 +563,9 @@ class TasteTestServiceEdgeCaseTest(TestCase):
 
         # 모든 점수가 0이므로 미식가유형이어야 함
         self.assertEqual(result["type"], "미식가유형")
-        self.assertEqual(result["info"]["image_url"], "images/types/gourmet.png")
+        # 이미지 정보 확인 - 서비스 메서드와 일치
+        expected_url = TasteTestService.get_image_url_by_enum("GOURMET")
+        self.assertEqual(result["info"]["image_url"], expected_url)
         total_score = sum(result["scores"].values())
         self.assertEqual(total_score, 0)
 
@@ -606,25 +625,29 @@ class TasteTestServiceEdgeCaseTest(TestCase):
         answers_1 = {"Q1": "A", "Q2": "A", "Q3": "A", "Q4": "B", "Q5": "B", "Q6": "B"}
         result_1 = TasteTestService.process_taste_test(answers_1)
         self.assertEqual(result_1["type"], "상큼깔끔파")
-        self.assertEqual(result_1["info"]["image_url"], "images/types/fresh_clean.png")
+        expected_url_1 = TasteTestService.get_image_url_by_enum("FRESH_CLEAN")
+        self.assertEqual(result_1["info"]["image_url"], expected_url_1)
 
         # 시나리오 2: 묵직달콤파 (달콤과일파 + 묵직여운파)
         answers_2 = {"Q1": "A", "Q2": "A", "Q3": "B", "Q4": "B", "Q5": "B", "Q6": "A"}
         result_2 = TasteTestService.process_taste_test(answers_2)
         self.assertEqual(result_2["type"], "묵직달콤파")
-        self.assertEqual(result_2["info"]["image_url"], "images/types/heavy_sweet.png")
+        expected_url_2 = TasteTestService.get_image_url_by_enum("HEAVY_SWEET")
+        self.assertEqual(result_2["info"]["image_url"], expected_url_2)
 
         # 시나리오 3: 달콤고소파 (달콤과일파 + 깔끔고소파)
         answers_3 = {"Q1": "A", "Q2": "B", "Q3": "A", "Q4": "B", "Q5": "A", "Q6": "B"}
         result_3 = TasteTestService.process_taste_test(answers_3)
         self.assertEqual(result_3["type"], "달콤고소파")
-        self.assertEqual(result_3["info"]["image_url"], "images/types/sweet_savory.png")
+        expected_url_3 = TasteTestService.get_image_url_by_enum("SWEET_SAVORY")
+        self.assertEqual(result_3["info"]["image_url"], expected_url_3)
 
         # 시나리오 4: 상큼톡톡파 단일 유형
         answers_4 = {"Q1": "B", "Q2": "A", "Q3": "A", "Q4": "A", "Q5": "A", "Q6": "B"}
         result_4 = TasteTestService.process_taste_test(answers_4)
         self.assertEqual(result_4["type"], "상큼톡톡파")  # 3점 단일 유형
-        self.assertEqual(result_4["info"]["image_url"], "images/types/fresh_fizzy.png")
+        expected_url_4 = TasteTestService.get_image_url_by_enum("FRESH_FIZZY")
+        self.assertEqual(result_4["info"]["image_url"], expected_url_4)
 
 
 class TasteTestServiceIntegrationWithImageTest(TestCase):
@@ -646,9 +669,10 @@ class TasteTestServiceIntegrationWithImageTest(TestCase):
         self.assertIn("scores", result)
         self.assertIn("info", result)
 
-        # 3. 이미지 정보 확인
+        # 3. 이미지 정보 확인 - 서비스 메서드와 일치
         self.assertIn("image_url", result["info"])
-        self.assertEqual(result["info"]["image_url"], "images/types/sweet_fruit.png")
+        expected_url = TasteTestService.get_image_url_by_enum("SWEET_FRUIT")
+        self.assertEqual(result["info"]["image_url"], expected_url)
 
         # 4. DB 저장 후 확인
         saved_result = TasteTestService.save_test_result(self.user, answers)
@@ -656,14 +680,15 @@ class TasteTestServiceIntegrationWithImageTest(TestCase):
 
         # 5. 이미지 URL 직접 조회
         image_url = TasteTestService.get_image_url_by_enum(saved_result.prefer_taste)
-        self.assertEqual(image_url, "images/types/sweet_fruit.png")
+        self.assertEqual(image_url, expected_url)
 
     def test_all_types_have_unique_images(self):
         """모든 유형이 고유한 이미지를 가지는지 테스트"""
         from ..services import TASTE_TYPES
 
         image_urls = []
-        for type_name, type_info in TASTE_TYPES.items():
+        for type_name in TASTE_TYPES.keys():
+            type_info = TasteTestService.get_type_info(type_name)
             image_url = type_info["image_url"]
             # 중복 이미지 URL이 없는지 확인
             self.assertNotIn(image_url, image_urls, f"{type_name}의 이미지가 중복됩니다")
@@ -678,13 +703,19 @@ class TasteTestServiceIntegrationWithImageTest(TestCase):
 
         for type_name, type_info in TASTE_TYPES.items():
             with self.subTest(type_name=type_name):
-                image_url = type_info["image_url"]
+                # 서비스 메서드를 통해 실제 URL 가져오기
+                actual_type_info = TasteTestService.get_type_info(type_name)
+                image_url = actual_type_info["image_url"]
 
-                # 경로 형식 확인
-                self.assertTrue(image_url.startswith("images/types/"))
+                # 절대 URL 형식 확인
+                self.assertTrue(image_url.startswith(('http://', 'https://')))
                 self.assertTrue(image_url.endswith(".png"))
 
                 # 파일명 형식 확인 (enum을 소문자로 변환한 형태)
                 enum_value = type_info["enum"]
                 expected_filename = enum_value.lower() + ".png"
                 self.assertTrue(image_url.endswith(expected_filename))
+
+                # 경로 형식 확인
+                expected_path = f"/api/v1/taste-test/images/types/{expected_filename}"
+                self.assertTrue(image_url.endswith(expected_path))

--- a/apps/taste_test/tests/test_views.py
+++ b/apps/taste_test/tests/test_views.py
@@ -9,6 +9,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from ..models import PreferenceTestResult
+from ..services import TasteTestService
 
 User = get_user_model()
 
@@ -42,9 +43,12 @@ class TasteTestAPITest(APITestCase):
         self.assertIn("info", response.data)
         self.assertIn("saved", response.data)
 
-        # 이미지 정보 확인
+        # 이미지 정보 확인 - 절대 URL 형식
         self.assertIn("image_url", response.data["info"])
-        self.assertTrue(response.data["info"]["image_url"].startswith("images/types/"))
+        image_url = response.data["info"]["image_url"]
+        self.assertTrue(image_url.startswith(('http://', 'https://')))
+        self.assertTrue(image_url.endswith('.png'))
+        self.assertIn('/api/v1/taste-test/images/types/', image_url)
         self.assertTrue(response.data["saved"])  # 로그인한 상태이므로 저장됨
 
     def test_submit_answers_without_auth(self):
@@ -83,6 +87,11 @@ class TasteTestAPITest(APITestCase):
         self.assertIn("prefer_taste_display", response.data)
         self.assertIn("created_at", response.data)
 
+        # 이미지 URL 형식 확인
+        image_url = response.data["image_url"]
+        self.assertTrue(image_url.startswith(('http://', 'https://')))
+        self.assertTrue(image_url.endswith('.png'))
+
     def test_get_profile_without_result(self):
         """프로필 조회 (테스트 결과 없음)"""
         url = reverse("taste_test:profile")
@@ -112,6 +121,12 @@ class TasteTestAPITest(APITestCase):
             self.assertIn("description", taste_type)
             self.assertIn("characteristics", taste_type)
 
+            # 이미지 URL 형식 확인
+            image_url = taste_type["image_url"]
+            self.assertTrue(image_url.startswith(('http://', 'https://')))
+            self.assertTrue(image_url.endswith('.png'))
+            self.assertIn('/api/v1/taste-test/images/types/', image_url)
+
     def test_retake_success(self):
         """재테스트 성공"""
         # 기존 결과 생성
@@ -132,8 +147,11 @@ class TasteTestAPITest(APITestCase):
         self.assertIn("saved", response.data)
         self.assertTrue(response.data["saved"])
 
-        # 이미지 정보 확인
+        # 이미지 정보 확인 - 절대 URL 형식
         self.assertIn("image_url", response.data["info"])
+        image_url = response.data["info"]["image_url"]
+        self.assertTrue(image_url.startswith(('http://', 'https://')))
+        self.assertTrue(image_url.endswith('.png'))
 
     def test_retake_no_existing_result(self):
         """재테스트 - 기존 결과 없음"""

--- a/apps/taste_test/tests/test_views.py
+++ b/apps/taste_test/tests/test_views.py
@@ -46,9 +46,9 @@ class TasteTestAPITest(APITestCase):
         # 이미지 정보 확인 - 절대 URL 형식
         self.assertIn("image_url", response.data["info"])
         image_url = response.data["info"]["image_url"]
-        self.assertTrue(image_url.startswith(('http://', 'https://')))
-        self.assertTrue(image_url.endswith('.png'))
-        self.assertIn('/api/v1/taste-test/images/types/', image_url)
+        self.assertTrue(image_url.startswith(("http://", "https://")))
+        self.assertTrue(image_url.endswith(".png"))
+        self.assertIn("/api/v1/taste-test/images/types/", image_url)
         self.assertTrue(response.data["saved"])  # 로그인한 상태이므로 저장됨
 
     def test_submit_answers_without_auth(self):
@@ -89,8 +89,8 @@ class TasteTestAPITest(APITestCase):
 
         # 이미지 URL 형식 확인
         image_url = response.data["image_url"]
-        self.assertTrue(image_url.startswith(('http://', 'https://')))
-        self.assertTrue(image_url.endswith('.png'))
+        self.assertTrue(image_url.startswith(("http://", "https://")))
+        self.assertTrue(image_url.endswith(".png"))
 
     def test_get_profile_without_result(self):
         """프로필 조회 (테스트 결과 없음)"""
@@ -123,9 +123,9 @@ class TasteTestAPITest(APITestCase):
 
             # 이미지 URL 형식 확인
             image_url = taste_type["image_url"]
-            self.assertTrue(image_url.startswith(('http://', 'https://')))
-            self.assertTrue(image_url.endswith('.png'))
-            self.assertIn('/api/v1/taste-test/images/types/', image_url)
+            self.assertTrue(image_url.startswith(("http://", "https://")))
+            self.assertTrue(image_url.endswith(".png"))
+            self.assertIn("/api/v1/taste-test/images/types/", image_url)
 
     def test_retake_success(self):
         """재테스트 성공"""
@@ -150,8 +150,8 @@ class TasteTestAPITest(APITestCase):
         # 이미지 정보 확인 - 절대 URL 형식
         self.assertIn("image_url", response.data["info"])
         image_url = response.data["info"]["image_url"]
-        self.assertTrue(image_url.startswith(('http://', 'https://')))
-        self.assertTrue(image_url.endswith('.png'))
+        self.assertTrue(image_url.startswith(("http://", "https://")))
+        self.assertTrue(image_url.endswith(".png"))
 
     def test_retake_no_existing_result(self):
         """재테스트 - 기존 결과 없음"""

--- a/apps/taste_test/views.py
+++ b/apps/taste_test/views.py
@@ -66,7 +66,7 @@ class TasteTestSubmitView(APIView):
                                 "enum": "SWEET_FRUIT",
                                 "description": "당신은 부드럽고 달콤한 맛에서 행복을 느끼는군요!",
                                 "characteristics": ["달콤함", "과일향", "로맨틱", "부드러움"],
-                                "image_url": "images/types/sweet_fruit.png",
+                                "image_url": "http://localhost:8000/images/types/sweet_fruit.png",
                             },
                             "saved": True,
                         },
@@ -165,7 +165,7 @@ class UserProfileView(APIView):
                     "prefer_taste": "SWEET_FRUIT",
                     "prefer_taste_display": "달콤과일파",
                     "taste_description": "당신은 부드럽고 달콤한 맛에서 행복을 느끼는군요!",
-                    "image_url": "images/types/sweet_fruit.png",
+                    "image_url": "http://localhost:8000/images/types/sweet_fruit.png",
                     "created_at": "2024-01-01T00:00:00Z",
                 },
             }
@@ -211,7 +211,7 @@ class TasteTypesView(APIView):
                             "enum": "SWEET_FRUIT",
                             "description": "당신은 부드럽고 달콤한 맛에서 행복을 느끼는군요!",
                             "characteristics": ["달콤함", "과일향", "로맨틱", "부드러움"],
-                            "image_url": "images/types/sweet_fruit.png",
+                            "image_url": "http://localhost:8000/images/types/sweet_fruit.png",
                         }
                     ],
                     "total": 9,
@@ -221,5 +221,11 @@ class TasteTypesView(APIView):
         tags=["정보"],
     )
     def get(self, request):
-        types_data = list(TasteTestData.TYPE_INFO.values())
+        # 절대 URL로 변환하여 반환
+        types_data = []
+        for type_info in TasteTestData.TYPE_INFO.values():
+            type_info_copy = type_info.copy()
+            type_info_copy['image_url'] = TasteTestService.get_image_url_by_enum(type_info['enum'])
+            types_data.append(type_info_copy)
+
         return Response({"types": types_data, "total": len(types_data)}, status=status.HTTP_200_OK)

--- a/apps/taste_test/views.py
+++ b/apps/taste_test/views.py
@@ -225,7 +225,7 @@ class TasteTypesView(APIView):
         types_data = []
         for type_info in TasteTestData.TYPE_INFO.values():
             type_info_copy = type_info.copy()
-            type_info_copy['image_url'] = TasteTestService.get_image_url_by_enum(type_info['enum'])
+            type_info_copy["image_url"] = TasteTestService.get_image_url_by_enum(type_info["enum"])
             types_data.append(type_info_copy)
 
         return Response({"types": types_data, "total": len(types_data)}, status=status.HTTP_200_OK)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -13,6 +13,9 @@ if not SECRET_KEY:
     raise ValueError("DJANGO_SECRET_KEY environment variable not set")
 DEBUG = True
 
+# BASE_URL 설정 추가 (개발환경 기본값)
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8000")
+
 # Application definition
 
 DJANGO_APPS = [

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -16,6 +16,9 @@ sentry_sdk.init(
 DEBUG = False
 ALLOWED_HOSTS = [host.strip() for host in os.environ.get("ALLOWED_HOSTS", "").split(",") if host.strip()]
 
+# 프로덕션 BASE_URL 설정 추가
+BASE_URL = "https://hanjantest.store"
+
 DATABASES: Dict[str, Dict[str, Any]] = {  # type: ignore[no-redef]
     "default": {
         "ENGINE": "django.db.backends.postgresql",

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
 ]
 
 # 이미지 서빙 설정 (개발/배포 환경 모두)
-urlpatterns += static('/api/v1/taste-test/images/', document_root=settings.BASE_DIR / 'images')
+urlpatterns += static("/api/v1/taste-test/images/", document_root=settings.BASE_DIR / "images")
 
 # if settings.DEBUG:
 #     if "debug_toolbar" in settings.INSTALLED_APPS:

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,21 +1,5 @@
-"""
-URL configuration for config project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-
 from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import (
@@ -40,6 +24,9 @@ urlpatterns = [
     path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
     path("__debug__/", include("debug_toolbar.urls")),
 ]
+
+# 이미지 서빙 설정 (개발/배포 환경 모두)
+urlpatterns += static('/api/v1/taste-test/images/', document_root=settings.BASE_DIR / 'images')
 
 # if settings.DEBUG:
 #     if "debug_toolbar" in settings.INSTALLED_APPS:


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 취향 테스트 이미지 URL을 상대경로에서 절대경로로 변경 및 설명문 개행 추가

## 📄 상세 내용
- [x] 취향 테스트 이미지 URL을 절대경로로 변경 (`http://localhost:8000/api/v1/taste-test/images/types/`)
- [x] Django static 파일 서빙 설정 추가 (개발/배포 환경 모두)
- [x] 취향 유형 설명문에 적절한 개행(`\n`) 추가로 가독성 향상
- [x] TasteTestService의 이미지 URL 생성 메서드 개선 (BASE_URL 설정 활용)
- [x] 모든 API 응답에서 절대 URL 반환 (프론트엔드에서 즉시 사용 가능)
- [x] 테스트 코드 수정 (환경에 무관하게 작동하도록 개선)

## 📸 스크린샷 (선택)
```json
// 변경 전 (상대경로)
{
  "info": {
    "image_url": "images/types/sweet_fruit.png"
  }
}

// 변경 후 (절대경로)
{
  "info": {
    "image_url": "http://localhost:8000/api/v1/taste-test/images/types/sweet_fruit.png"
  }
}
```

## 📝 기타 참고 사항
- BASE_URL 설정을 통해 개발환경(`http://localhost:8000`)과 배포환경(`https://hanjantest.store`) 자동 대응
- 기존 API 구조는 유지하면서 이미지 URL만 절대경로로 변경
- 프론트엔드에서 별도 URL 조합 없이 바로 사용 가능

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] mypy 타입 체크 통과
- [x] 모든 단위 테스트 통과 (146개 테스트)