### PR TITLE
🐛 fix: 메인페이지 섹션별 필터링 오류 수정

### DIFF
--- a/apps/products/services/product_service.py
+++ b/apps/products/services/product_service.py
@@ -128,7 +128,8 @@ class ProductService:
         elif section_type == "regional":
             # 패키지페이지용: 지역특산주 패키지만
             return base_queryset.filter(is_regional_specialty=True, package__isnull=False).order_by("-created_at")[
-                   :limit]
+                :limit
+            ]
 
         else:
             return base_queryset.none()

--- a/apps/products/services/product_service.py
+++ b/apps/products/services/product_service.py
@@ -102,25 +102,24 @@ class ProductService:
         base_queryset = ProductService.get_product_list_queryset()
 
         if section_type == "popular":
-            return base_queryset.order_by("-view_count")[:limit]
+            # 메인페이지용: 인기 패키지만
+            return base_queryset.filter(package__isnull=False).order_by("-view_count")[:limit]
 
         elif section_type == "featured":
-            # 패키지페이지용: 프리미엄 패키지만
-            return base_queryset.filter(is_premium=True, package__isnull=False).order_by("-created_at")[  # 패키지만
-                :limit
-            ]
+            # 패키지페이지용: 추천 패키지 (최신순 또는 조회수순)
+            return base_queryset.filter(package__isnull=False).order_by("-created_at")[:limit]
 
         elif section_type == "recommended":
+            # 메인페이지용: 추천 전통주 (개별 상품만)
             return base_queryset.filter(drink__isnull=False).order_by("-created_at")[:limit]
 
         elif section_type == "monthly":
+            # 메인페이지용: 이달의 전통주 (개별 상품만)
             return base_queryset.filter(drink__isnull=False).order_by("-view_count")[:3]
 
         elif section_type == "award_winning":
             # 패키지페이지용: 수상작 패키지만
-            return base_queryset.filter(is_award_winning=True, package__isnull=False).order_by(  # 패키지만
-                "-order_count"
-            )[:limit]
+            return base_queryset.filter(is_award_winning=True, package__isnull=False).order_by("-order_count")[:limit]
 
         elif section_type == "makgeolli":
             # 패키지페이지 전용: 막걸리 패키지만
@@ -128,9 +127,8 @@ class ProductService:
 
         elif section_type == "regional":
             # 패키지페이지용: 지역특산주 패키지만
-            return base_queryset.filter(is_regional_specialty=True, package__isnull=False).order_by(  # 패키지만
-                "-created_at"
-            )[:limit]
+            return base_queryset.filter(is_regional_specialty=True, package__isnull=False).order_by("-created_at")[
+                   :limit]
 
         else:
             return base_queryset.none()

--- a/apps/products/tests/test_services.py
+++ b/apps/products/tests/test_services.py
@@ -83,15 +83,17 @@ class ProductServiceTest(BaseServiceTestCase):
 
     def test_get_section_products_featured(self):
         """추천 패키지 섹션 테스트"""
-        # 프리미엄 상품 설정
-        self.all_products[0].is_premium = True
-        self.all_products[0].save()
-
         products = ProductService.get_section_products("featured", limit=4)
 
-        # 프리미엄 상품만 반환되는지 확인
+        # 패키지 상품만 반환되는지 확인
         for product in products:
-            self.assertTrue(product.is_premium)
+            self.assertIsNotNone(product.package)
+            self.assertIsNone(product.drink)
+
+        # 최신순으로 정렬되는지 확인 (created_at 기준)
+        if len(products) > 1:
+            for i in range(len(products) - 1):
+                self.assertGreaterEqual(products[i].created_at, products[i + 1].created_at)
 
     def test_get_section_products_invalid_type(self):
         """잘못된 섹션 타입 테스트"""


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호:
- 작업 요약: 메인페이지와 패키지페이지 섹션별 필터링 정확도 개선

## 📄 상세 내용
- [x] 인기 패키지 섹션에 `package__isnull=False` 필터 추가
- [x] 추천 패키지 섹션을 프리미엄 조건에서 최신순 패키지로 변경
- [x] 추천 전통주 섹션에서 개별 상품만 필터링하도록 유지
- [x] 메인페이지와 패키지페이지 섹션 목적에 맞는 필터링 적용

## 📸 스크린샷 (선택)
N/A

## 📝 기타 참고 사항
- 메인페이지: 인기 패키지(패키지만), 추천 전통주(개별만), 이달의 전통주(개별만)
- 패키지페이지: 모든 섹션이 패키지만 필터링됨

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).